### PR TITLE
Add a couple of tweaks

### DIFF
--- a/charts/datacenter/pipelines/templates/gitea-admin-secret.yaml
+++ b/charts/datacenter/pipelines/templates/gitea-admin-secret.yaml
@@ -1,6 +1,8 @@
 # The push secret fetches the randomly generated gitea-admin-secret username+password to vault
 # The External Secret will fetch those credentials from vault and place them in the gitea-admin-external-secret
 # in the manuela-ci namespace
+{{- if .Values.clusterGroup.isHubCluster }}
+{{- if .Values.global.originURL }}
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
@@ -48,3 +50,5 @@ spec:
   dataFrom:
   - extract:
       key: "pushsecrets/gitea_admin"
+{{- end }}
+{{- end }}

--- a/charts/datacenter/pipelines/templates/gitea-admin-secret.yaml
+++ b/charts/datacenter/pipelines/templates/gitea-admin-secret.yaml
@@ -50,5 +50,23 @@ spec:
   dataFrom:
   - extract:
       key: "pushsecrets/gitea_admin"
+---
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: gitea-admin-external-secret
+  namespace: ml-development
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: {{ $.Values.secretStore.name }}
+    kind: {{ $.Values.secretStore.kind }}
+  target:
+    name: gitea-admin-secret
+    template:
+      type: Opaque
+  dataFrom:
+  - extract:
+      key: "pushsecrets/gitea_admin"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- **Only use the pushsecret on the hub and when gitea is being used**
- **Also have the gitea admin secret in the ml-development ns**
